### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 pytest-sftpserver
 =================
 
-.. image:: https://pypip.in/version/pytest-sftpserver/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/pytest-sftpserver.svg?style=flat
     :target: https://pypi.python.org/pypi/pytest-sftpserver/
     :alt: Latest Version
 .. image:: http://img.shields.io/travis/ulope/pytest-sftpserver.svg?branch=master&style=flat
@@ -11,10 +11,10 @@ pytest-sftpserver
 .. image:: https://img.shields.io/coveralls/ulope/pytest-sftpserver.svg?branch=master&style=flat
     :target: https://coveralls.io/r/ulope/pytest-sftpserver?branch=master
     :alt: Code coverage
-.. image:: https://pypip.in/py_versions/pytest-sftpserver/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/pytest-sftpserver.svg?style=flat
     :target: https://pypi.python.org/pypi/pytest-sftpserver/
     :alt: Supported versions
-.. image:: https://pypip.in/license/pytest-sftpserver/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/pytest-sftpserver.svg?style=flat
     :target: https://pypi.python.org/pypi/pytest-sftpserver/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pytest-sftpserver))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pytest-sftpserver`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.