### PR TITLE
SFTP reads are supposed to be binary, so don't wrap with str()

### DIFF
--- a/pytest_sftpserver/sftp/interface.py
+++ b/pytest_sftpserver/sftp/interface.py
@@ -44,7 +44,7 @@ class VirtualSFTPHandle(SFTPHandle):
             return SFTP_NO_SUCH_FILE
 
         end = offset + length
-        return str(self.content_provider.get(self.path))[offset:end]
+        return self.content_provider.get(self.path)[offset:end]
 
     def stat(self):
         if self.content_provider.get(self.path) is None:

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -95,6 +95,15 @@ def test_sftpserver_put_file(content, sftpclient, tmpdir):
     assert set(sftpclient.listdir("/a")) == set(["test.txt", "b", "c", "f"])
 
 
+def test_sftpserver_round_trip(content, sftpclient, tmpdir):
+    tmpfile = tmpdir.join("test.txt")
+    thetext = u"Just some plain, normal text"
+    tmpfile.write(thetext)
+    sftpclient.put(str(tmpfile), "/a/test.txt")
+    with sftpclient.open("/a/test.txt", "r") as result:
+        assert result.read() == thetext.encode()
+
+
 def test_sftpserver_remove_file_dict(content, sftpclient):
     sftpclient.remove("/a/c")
     assert set(sftpclient.listdir("/a")) == set(["b", "f"])


### PR DESCRIPTION
Discovered this as I was porting a project over to py3k. My tests had some round-trippers that were ending up as `b"b'foobar'"`, which would fail my unit test. This happens in py3k when casting a bytes object into a string. Since paramiko does everything as bytes in py3k (as per the SFTP specs), this would result in bad results being read back in a round-trip scenario.

The existing tests didn't notice this because any tests that wrote to the content provider never read it back, and any tests that read stuff back only read back entries in the existing content provider fixture. which were are already string objects. I added a round-trip test that fails without this change and passes with it.