### PR TITLE
Support offset in write

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [tool.black]
 line-length = 99
-

--- a/pytest_sftpserver/sftp/interface.py
+++ b/pytest_sftpserver/sftp/interface.py
@@ -8,11 +8,11 @@ from datetime import datetime
 from os import O_CREAT
 
 from paramiko import AUTH_SUCCESSFUL, OPEN_SUCCEEDED, ServerInterface
-from paramiko.sftp import SFTP_FAILURE, SFTP_NO_SUCH_FILE, SFTP_OK, SFTP_OP_UNSUPPORTED
+from paramiko.sftp import SFTP_FAILURE, SFTP_NO_SUCH_FILE, SFTP_OK
 from paramiko.sftp_attr import SFTPAttributes
 from paramiko.sftp_handle import SFTPHandle
 from paramiko.sftp_si import SFTPServerInterface
-from six import string_types
+from six import string_types, text_type
 
 from pytest_sftpserver.sftp.util import abspath
 
@@ -40,14 +40,19 @@ class VirtualSFTPHandle(SFTPHandle):
 
         if content is None:
             return SFTP_OK if self.content_provider.put(self.path, data) else SFTP_NO_SUCH_FILE
+
         if not isinstance(content, string_types):
             # Can't offset write into a 'directory' or integer
             return SFTP_FAILURE
-        if offset > len(content):
-            return SFTP_FAILURE
 
-        new_data = content[:offset] + data + content[offset + len(data):]
-        return SFTP_OK if self.content_provider.put(self.path, new_data) else SFTP_FAILURE
+        if isinstance(content, text_type):
+            content = content.encode()
+
+        if offset > len(content):
+            content = content + b"\x00" * (offset - len(content))
+
+        content = content[:offset] + data + content[offset + len(data) :]
+        return SFTP_OK if self.content_provider.put(self.path, content) else SFTP_FAILURE
 
     def read(self, offset, length):
         if self.content_provider.get(self.path) is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ universal=1
 
 [flake8]
 max-line-length = 99
+ignore = E203,W503
 
 [pep8]
 max-line-length = 99

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -69,11 +69,21 @@ def test_sftpserver_get_file_list(content, sftpclient):
         assert f.read() == b"testfile5"
 
 
-def test_sftpserver_write_offset_unsupported(content, sftpclient):
-    with sftpclient.open("/a/f/0", "w") as f:
-        f.seek(1)
-        with pytest.raises(IOError):
-            f.write("test")
+@pytest.mark.parametrize(
+    ("offset", "data", "expected"),
+    [
+        (4, "test", b"testtest6"),
+        (5, "test", b"testftest"),
+        (9, "test", b"testfile6test"),
+        (10, "test", b"testfile6\x00test"),
+    ],
+)
+def test_sftpserver_put_file_offset(content, sftpclient, offset, data, expected):
+    with sftpclient.open("/a/f/1", "rw") as f:
+        f.seek(offset)
+        f.write(data)
+        f.seek(0)
+        assert f.read() == expected
 
 
 def test_sftpserver_put_file_dict(content, sftpclient):


### PR DESCRIPTION
Replaces: #11 

Support the `offset` parameter on calls to `write()`.
Thanks @DrNecromant for the initial implementation.
