### PR TITLE
Refactor the code to enable use of the local server without pytest.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ It is also possible to use the package without `pytest`:
 
     from pytest_sftpserver import sftpserver_factory
 
-    @sftpserver_factory
+    @sftpserver_factory()
     def test_sftp_fetch(sftpserver):
         with sftpserver.serve_content({'a_dir': {'somefile.txt': "File content"}}):
             assert get_sftp_file(sftpserver.host, sftpserver.port, "user",

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,17 @@ simply by adding a parameter named `sftpserver` to your test function:
 As can be seen from this example `sftpserver` serves content directly from
 python objects instead of files.
 
+It is also possible to use the package without `pytest`:
+
+.. code-block:: python
+
+    from pytest_sftpserver import sftpserver_factory
+
+    @sftpserver_factory
+    def test_sftp_fetch(sftpserver):
+        with sftpserver.serve_content({'a_dir': {'somefile.txt': "File content"}}):
+            assert get_sftp_file(sftpserver.host, sftpserver.port, "user",
+                                 "pw", "/a_dir/somefile.txt") == "File content"
 
 Installation
 ============

--- a/pytest_sftpserver/__init__.py
+++ b/pytest_sftpserver/__init__.py
@@ -1,3 +1,5 @@
+from pytest_sftpserver.decorator import sftpserver_factory  # noqa: F401
+
 VERSION = (1, 3, 0)
 
 

--- a/pytest_sftpserver/__init__.py
+++ b/pytest_sftpserver/__init__.py
@@ -1,7 +1,2 @@
 from pytest_sftpserver.decorator import sftpserver_factory  # noqa: F401
-
-VERSION = (1, 3, 0)
-
-
-def get_version():
-    return ".".join(str(i) for i in VERSION)
+from .__version__ import VERSION, get_version  # noqa: F401

--- a/pytest_sftpserver/__init__.py
+++ b/pytest_sftpserver/__init__.py
@@ -1,2 +1,3 @@
 from pytest_sftpserver.decorator import sftpserver_factory  # noqa: F401
+
 from .__version__ import VERSION, get_version  # noqa: F401

--- a/pytest_sftpserver/__version__.py
+++ b/pytest_sftpserver/__version__.py
@@ -1,0 +1,5 @@
+VERSION = (1, 3, 0)
+
+
+def get_version():
+    return '.'.join(str(i) for i in VERSION)

--- a/pytest_sftpserver/__version__.py
+++ b/pytest_sftpserver/__version__.py
@@ -2,4 +2,4 @@ VERSION = (1, 3, 0)
 
 
 def get_version():
-    return '.'.join(str(i) for i in VERSION)
+    return ".".join(str(i) for i in VERSION)

--- a/pytest_sftpserver/decorator.py
+++ b/pytest_sftpserver/decorator.py
@@ -1,0 +1,23 @@
+from functools import wraps
+
+from pytest_sftpserver.sftp.server import SFTPServer
+
+
+class sftpserver_factory(object):
+    def __enter__(self):
+        self.server = SFTPServer()
+        self.server.start()
+        return self.server
+
+    def __exit__(self, *args, **kwargs):
+        if self.server.is_alive():
+            self.server.shutdown()
+
+    def __call__(self, func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with self:
+                kwargs["sftpserver"] = self.server
+                return func(*args, **kwargs)
+
+        return wrapper

--- a/pytest_sftpserver/plugin.py
+++ b/pytest_sftpserver/plugin.py
@@ -3,15 +3,10 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from pytest_sftpserver.sftp.server import SFTPServer
+from pytest_sftpserver.decorator import sftpserver_factory
 
 
 @pytest.yield_fixture(scope="session")
 def sftpserver(request):
-    server = SFTPServer()
-    server.start()
-
-    yield server
-
-    if server.is_alive():
-        server.shutdown()
+    with sftpserver_factory() as server:
+        yield server

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,25 @@
+import codecs
+import os
+import re
+
 from setuptools import setup, find_packages, Command
 
+here = os.path.abspath(os.path.dirname(__file__))
 
-version = __import__('pytest_sftpserver').get_version()
+
+def read(*parts):
+    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(
+        r"^VERSION = \(([^\)]*)\)", version_file, re.M
+    )
+    if version_match:
+        return '.'.join(i.strip() for i in version_match.group(1).split(','))
+    raise RuntimeError('Unable to find version string.')
 
 
 class Test(Command):
@@ -23,7 +41,7 @@ with open("README.rst", "r") as readme:
 
 setup(
     name='pytest-sftpserver',
-    version=version,
+    version=find_version('pytest_sftpserver', '__version__.py'),
     author='Ulrich Petri',
     author_email='mail@ulo.pe',
     license='MIT License',

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -6,6 +6,7 @@ from paramiko import Transport
 from paramiko.channel import Channel
 from paramiko.sftp_client import SFTPClient
 
+from pytest_sftpserver import sftpserver_factory
 from pytest_sftpserver.sftp.server import SFTPServer
 
 # fmt: off
@@ -188,3 +189,8 @@ def test_sftpserver_chmod_non_existing(sftpclient, sftpserver):
     with sftpserver.serve_content({}):
         with pytest.raises(IOError):
             sftpclient.chmod("/a", 600)
+
+
+@sftpserver_factory()
+def test_decorator(sftpserver):
+    assert isinstance(sftpserver, SFTPServer)


### PR DESCRIPTION
Hi there! 

Picking up this again now that I have another project that needs a proper SFTP server mock, but runs without pytest. I have corrected the code according to your suggestions, but somehow a force-push automatically closed my previous PR #6. Oh, well. Here comes a new one! 🙁 Let me know if you have any further suggestions.

Original PR description:
> I work on a project that requires a mock SFTP server, but it is not pytest-based. This little patch makes it very easy to use it directly, without pytest, while maintaining everything backward compatibile.