### PR TITLE
Fix put of existing file

### DIFF
--- a/pytest_sftpserver/sftp/interface.py
+++ b/pytest_sftpserver/sftp/interface.py
@@ -12,7 +12,7 @@ from paramiko.sftp import SFTP_FAILURE, SFTP_NO_SUCH_FILE, SFTP_OK
 from paramiko.sftp_attr import SFTPAttributes
 from paramiko.sftp_handle import SFTPHandle
 from paramiko.sftp_si import SFTPServerInterface
-from six import string_types, text_type, binary_type
+from six import binary_type, string_types, text_type
 
 from pytest_sftpserver.sftp.util import abspath
 

--- a/pytest_sftpserver/sftp/interface.py
+++ b/pytest_sftpserver/sftp/interface.py
@@ -41,7 +41,7 @@ class VirtualSFTPHandle(SFTPHandle):
         if content is None:
             return SFTP_OK if self.content_provider.put(self.path, data) else SFTP_NO_SUCH_FILE
 
-        if not isinstance(content, (string_types, binary_type)):
+        if not isinstance(content, string_types + (binary_type,)):
             # Can't offset write into a 'directory' or integer
             return SFTP_FAILURE
 

--- a/pytest_sftpserver/sftp/interface.py
+++ b/pytest_sftpserver/sftp/interface.py
@@ -12,7 +12,7 @@ from paramiko.sftp import SFTP_FAILURE, SFTP_NO_SUCH_FILE, SFTP_OK
 from paramiko.sftp_attr import SFTPAttributes
 from paramiko.sftp_handle import SFTPHandle
 from paramiko.sftp_si import SFTPServerInterface
-from six import string_types, text_type
+from six import string_types, text_type, binary_type
 
 from pytest_sftpserver.sftp.util import abspath
 
@@ -41,7 +41,7 @@ class VirtualSFTPHandle(SFTPHandle):
         if content is None:
             return SFTP_OK if self.content_provider.put(self.path, data) else SFTP_NO_SUCH_FILE
 
-        if not isinstance(content, string_types):
+        if not isinstance(content, (string_types, binary_type)):
             # Can't offset write into a 'directory' or integer
             return SFTP_FAILURE
 

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -112,8 +112,8 @@ def test_sftpserver_put_file_existing(content, sftpclient, tmpdir):
     tmpfile.write("new content")
     sftpclient.put(str(tmpfile), "/test.txt")
 
-    with sftpclient.open("/test.txt") as asp:
-        assert asp.read() == "new content".encode()
+    with sftpclient.open("/test.txt") as f:
+        assert f.read() == "new content".encode()
 
 
 def test_sftpserver_round_trip(content, sftpclient, tmpdir):

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -104,6 +104,17 @@ def test_sftpserver_put_file(content, sftpclient, tmpdir):
     sftpclient.put(str(tmpfile), "/a/test.txt")
     assert set(sftpclient.listdir("/a")) == set(["test.txt", "b", "c", "f"])
 
+def test_sftpserver_put_file_existing(content, sftpclient, tmpdir):
+    tmpfile = tmpdir.join("test.txt")
+    tmpfile.write("old content")
+    sftpclient.put(str(tmpfile), "/test.txt")
+
+    tmpfile.write("new content")
+    sftpclient.put(str(tmpfile), "/test.txt")
+
+    with sftpclient.open("/test.txt") as asp:
+        assert asp.read() == "new content".encode()
+
 
 def test_sftpserver_round_trip(content, sftpclient, tmpdir):
     tmpfile = tmpdir.join("test.txt")

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -105,7 +105,7 @@ def test_sftpserver_put_file(content, sftpclient, tmpdir):
     assert set(sftpclient.listdir("/a")) == set(["test.txt", "b", "c", "f"])
 
 
-def test_sftpserver_put_file_existing(content, sftpclient, tmpdir):
+def test_sftpserver_put_existing_file(content, sftpclient, tmpdir):
     tmpfile = tmpdir.join("test.txt")
     tmpfile.write("old content")
     sftpclient.put(str(tmpfile), "/test.txt")

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -104,6 +104,7 @@ def test_sftpserver_put_file(content, sftpclient, tmpdir):
     sftpclient.put(str(tmpfile), "/a/test.txt")
     assert set(sftpclient.listdir("/a")) == set(["test.txt", "b", "c", "f"])
 
+
 def test_sftpserver_put_file_existing(content, sftpclient, tmpdir):
     tmpfile = tmpdir.join("test.txt")
     tmpfile.write("old content")


### PR DESCRIPTION
I noticed that when calling `put()` on an existing remote path, it fails because the existing `content` is of type `bytes`, which is not in Python 3 `six.string_types`, and `SFTP_FAILURE` is returned from `write()`.