### PR TITLE
 Call server_close() on shutdown 

### DIFF
--- a/pytest_sftpserver/plugin.py
+++ b/pytest_sftpserver/plugin.py
@@ -15,3 +15,4 @@ def sftpserver(request):
 
     if server.is_alive():
         server.shutdown()
+    server.server_close()


### PR DESCRIPTION
Server threads take some times to shutdown, calling ThreadMixin.server_close() will wait on those threads.

It prevents ResourceWarning about an unclosed listening socket after a pytest run.