### PR TITLE
Fix `is_dir` under Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-.tox
+__pycache__
 .coverage*
-htmlcov*
-coverage*.xml
 .pytest_cache
+.tox
+*.egg-info
+*.pyc
+coverage*.xml
+htmlcov*

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,12 @@ TODO
 Version History
 ===============
 
+1.3.1 - unreleased
+------------------
+
+- Fix ``is_dir`` under Python 3 no longer returning ``True`` for files with binary content. (#23, thanks @icemac)
+
+
 1.3.0 - 2019-09-16
 ------------------
 - Updated supported Python versions to 2.7, 3.5 - 3.7.

--- a/pytest_sftpserver/sftp/content_provider.py
+++ b/pytest_sftpserver/sftp/content_provider.py
@@ -64,8 +64,7 @@ class ContentProvider(object):
             return [n for n in dir(obj) if not n.startswith("__")]
 
     def is_dir(self, path):
-        return not isinstance(
-            self.get(path), (binary_type,) + string_types + integer_types)
+        return not isinstance(self.get(path), (binary_type,) + string_types + integer_types)
 
     def get_size(self, path):
         try:

--- a/pytest_sftpserver/sftp/content_provider.py
+++ b/pytest_sftpserver/sftp/content_provider.py
@@ -64,7 +64,8 @@ class ContentProvider(object):
             return [n for n in dir(obj) if not n.startswith("__")]
 
     def is_dir(self, path):
-        return not isinstance(self.get(path), string_types + integer_types)
+        return not isinstance(
+            self.get(path), (binary_type,) + string_types + integer_types)
 
     def get_size(self, path):
         try:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black==19.3b0;python_version>="3.6"
+click==8.0.4;python_version>="3.6"
 flake8==3.7.8
 flake8-bugbear==19.8.0;python_version>="3.5"
 flake8-tuple==0.4.0

--- a/tests/test_content_provider.py
+++ b/tests/test_content_provider.py
@@ -24,6 +24,7 @@ _CONTENT_OBJ = dict(
         f=["testfile5", "testfile6"]
     ),
     d="testfile3",
+    g=b"testfile7",
     o=_TestObj(),
 )
 # fmt: on
@@ -107,7 +108,7 @@ def test_remove_obj_fail(content_provider):
 
 
 def test_list_root(content_provider):
-    assert set(content_provider.list("/")) == set(["a", "d", "o"])
+    assert set(content_provider.list("/")) == set(["a", "d", "g", "o"])
 
 
 def test_list_sub(content_provider):
@@ -120,6 +121,7 @@ def test_is_dir(content_provider):
     assert content_provider.is_dir("/a")
     assert content_provider.is_dir("/a/f")
     assert content_provider.is_dir("/o")
+    assert not content_provider.is_dir("/g")
     assert not content_provider.is_dir("/d")
 
 

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -20,7 +20,7 @@ CONTENT_OBJ = dict(
 # fmt: on
 
 
-@pytest.yield_fixture(scope="session")
+@pytest.fixture(scope="session")
 def sftpclient(sftpserver):
     transport = Transport((sftpserver.host, sftpserver.port))
     transport.connect(username="a", password="b")
@@ -30,7 +30,7 @@ def sftpclient(sftpserver):
     transport.close()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def content(sftpserver):
     with sftpserver.serve_content(deepcopy(CONTENT_OBJ)):
         yield

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     paramiko
 
 commands =
-    coverage run --source tests,pytest_sftpserver --branch --parallel -m py.test []
+    coverage run --source tests,pytest_sftpserver --branch --parallel -m pytest []
 
 [testenv:cov-report]
 deps =


### PR DESCRIPTION
It is no longer returning `True` for files with binary content.

Fixes #23.