### PR TITLE
Byte data fix

### DIFF
--- a/pytest_sftpserver/sftp/interface.py
+++ b/pytest_sftpserver/sftp/interface.py
@@ -12,9 +12,11 @@ from paramiko.sftp import SFTP_FAILURE, SFTP_NO_SUCH_FILE, SFTP_OK
 from paramiko.sftp_attr import SFTPAttributes
 from paramiko.sftp_handle import SFTPHandle
 from paramiko.sftp_si import SFTPServerInterface
-from six import string_types, text_type
+from six import binary_type, string_types, text_type
 
 from pytest_sftpserver.sftp.util import abspath
+
+ACCEPTABLE_TYPES = string_types + (binary_type,)
 
 
 class VirtualSFTPHandle(SFTPHandle):
@@ -41,7 +43,7 @@ class VirtualSFTPHandle(SFTPHandle):
         if content is None:
             return SFTP_OK if self.content_provider.put(self.path, data) else SFTP_NO_SUCH_FILE
 
-        if not isinstance(content, string_types):
+        if not isinstance(content, ACCEPTABLE_TYPES):
             # Can't offset write into a 'directory' or integer
             return SFTP_FAILURE
 

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -32,8 +32,9 @@ def sftpclient(sftpserver):
 
 @pytest.yield_fixture
 def content(sftpserver):
-    with sftpserver.serve_content(deepcopy(CONTENT_OBJ)):
-        yield
+    actual_content = deepcopy(CONTENT_OBJ)
+    with sftpserver.serve_content(actual_content):
+        yield actual_content
 
 
 @pytest.mark.xfail(sys.version_info < (2, 7), reason="Intermittently broken on 2.6")
@@ -103,6 +104,14 @@ def test_sftpserver_put_file(content, sftpclient, tmpdir):
     tmpfile.write("Hello world")
     sftpclient.put(str(tmpfile), "/a/test.txt")
     assert set(sftpclient.listdir("/a")) == set(["test.txt", "b", "c", "f"])
+
+
+def test_sftpserver_put_bigger_file(content, sftpclient, tmpdir):
+    tmpfile = tmpdir.join("test.txt")
+    file_size = 40000
+    tmpfile.write("x" * file_size)
+    sftpclient.put(str(tmpfile), "/a/test.txt")
+    assert len(content["a"]["test.txt"]) == file_size
 
 
 def test_sftpserver_round_trip(content, sftpclient, tmpdir):


### PR DESCRIPTION
Addresses https://github.com/ulope/pytest-sftpserver/issues/33

Sftp Interface would not handle byte-data that was larger than 32768 bytes ([see Paramiko max length](https://github.com/paramiko/paramiko/blob/main/paramiko/sftp_file.py#L59))